### PR TITLE
Add rate limiting and update gateway settings with new features

### DIFF
--- a/backend/api-gateway/pom.xml
+++ b/backend/api-gateway/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/api-gateway/src/main/java/com/gosqu/gateway/config/CorsConfig.java
+++ b/backend/api-gateway/src/main/java/com/gosqu/gateway/config/CorsConfig.java
@@ -1,0 +1,32 @@
+package com.gosqu.gateway.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${cors.allowed-origins:http://localhost:4200}")
+    private String allowedOrigins;
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/backend/api-gateway/src/main/java/com/gosqu/gateway/config/GatewayRoutesConfig.java
+++ b/backend/api-gateway/src/main/java/com/gosqu/gateway/config/GatewayRoutesConfig.java
@@ -12,6 +12,27 @@ public class GatewayRoutesConfig {
     @Value("${service.auth-url}")
     private String authServiceUrl;
 
+    @Value("${service.user-url}")
+    private String userServiceUrl;
+
+    @Value("${service.restaurant-url}")
+    private String restaurantServiceUrl;
+
+    @Value("${service.order-url}")
+    private String orderServiceUrl;
+
+    @Value("${service.payment-url}")
+    private String paymentServiceUrl;
+
+    @Value("${service.notification-url}")
+    private String notificationsServiceUrl;
+
+    @Value("${service.delivery-url}")
+    private String deliveryServiceUrl;
+
+    @Value("${service.review-url}")
+    private String reviewServiceUrl;
+
     @Bean
     public RouteLocator routes(RouteLocatorBuilder builder) {
         return builder.routes()
@@ -19,9 +40,34 @@ public class GatewayRoutesConfig {
                         .path("/auth/**", "/login/oauth2/**", "/oauth2/authorization/**")
                         .uri(authServiceUrl)
                 )
-                // Future services will be added here:
-                // .route("restaurant-service", r -> r.path("/restaurants/**").uri(restaurantServiceUrl))
-                // .route("order-service", r -> r.path("/orders/**").uri(orderServiceUrl))
+                .route("user-service", r -> r
+                        .path("/users/**")
+                        .uri(userServiceUrl)
+                )
+                .route("restaurant-service", r -> r
+                        .path("/restaurants/**")
+                        .uri(restaurantServiceUrl)
+                )
+                .route("order-service", r -> r
+                        .path("/orders/**")
+                        .uri(orderServiceUrl)
+                )
+                .route("payment-service", r -> r
+                        .path("/payments/**")
+                        .uri(paymentServiceUrl)
+                )
+                .route("notification-service", r -> r
+                        .path("/notifications/**")
+                        .uri(notificationsServiceUrl)
+                )
+                .route("delivery-service", r -> r
+                        .path("/deliveries/**")
+                        .uri(deliveryServiceUrl)
+                )
+                .route("review-service", r -> r
+                        .path("/reviews/**")
+                        .uri(reviewServiceUrl)
+                )
                 .build();
     }
 }

--- a/backend/api-gateway/src/main/java/com/gosqu/gateway/filter/JwtAuthenticationFilter.java
+++ b/backend/api-gateway/src/main/java/com/gosqu/gateway/filter/JwtAuthenticationFilter.java
@@ -25,16 +25,26 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             "/auth/login",
             "/auth/verify-2fa",
             "/auth/reset-password",
-            "/auth/oauth2/failure",
+            "/auth/oauth2",
             "/login/oauth2",
-            "/oauth2/authorization",
-            "/actuator"
+            "/oauth2/authorization"
     );
 
     private final JwtUtil jwtUtil;
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        // Strip all trust headers unconditionally — clients must never inject these
+        ServerHttpRequest stripped = exchange.getRequest().mutate()
+                .headers(h -> {
+                    h.remove("X-User-Email");
+                    h.remove("X-User-Role");
+                    h.remove("X-User-Id");
+                    h.remove("X-Internal-Service");
+                })
+                .build();
+        exchange = exchange.mutate().request(stripped).build();
+
         String path = exchange.getRequest().getURI().getPath();
 
         if (PUBLIC_PATHS.stream().anyMatch(path::startsWith)) {
@@ -52,6 +62,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             ServerHttpRequest enrichedRequest = exchange.getRequest().mutate()
                     .header("X-User-Email", claims.getSubject())
                     .header("X-User-Role", claims.get("role", String.class))
+                    .header("X-User-Id", String.valueOf(claims.get("userId", Long.class)))
                     .build();
             return chain.filter(exchange.mutate().request(enrichedRequest).build());
         } catch (JwtException e) {

--- a/backend/api-gateway/src/main/java/com/gosqu/gateway/filter/RateLimitFilter.java
+++ b/backend/api-gateway/src/main/java/com/gosqu/gateway/filter/RateLimitFilter.java
@@ -1,0 +1,74 @@
+package com.gosqu.gateway.filter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitFilter implements GlobalFilter, Ordered {
+
+    private final ReactiveStringRedisTemplate redisTemplate;
+
+    @Value("${rate-limit.public.max:20}")
+    private int publicMax;
+
+    @Value("${rate-limit.auth.max:200}")
+    private int authMax;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String userId = exchange.getRequest().getHeaders().getFirst("X-User-Id");
+        String key = buildKey(exchange, userId);
+        int limit = userId != null ? authMax : publicMax;
+
+        return redisTemplate.opsForValue()
+                .increment(key)
+                .flatMap(count -> {
+                    if (count == 1) {
+                        redisTemplate.expire(key, Duration.ofSeconds(60)).subscribe();
+                    }
+                    if (count > limit) {
+                        return tooManyRequest(exchange);
+                    }
+                    return chain.filter(exchange);
+                });
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    private String buildKey(ServerWebExchange exchange, String userId) {
+        long window = System.currentTimeMillis() / 60_000; //okno minutowe
+        if (userId != null) {
+            return "rate_limit:user:" + userId + ":" + window;
+        }
+        return "rate_limit:ip:" + getClientIp(exchange) + ":" + window;
+    }
+
+    private String getClientIp(ServerWebExchange exchange) {
+        String forwarded = exchange.getRequest().getHeaders().getFirst("X-Forwarded-For");
+        if (forwarded != null) {
+            return forwarded.split(",")[0].trim();
+        }
+        var addr = exchange.getRequest().getRemoteAddress();
+        return addr != null ? addr.getAddress().getHostAddress() : "unknown";
+    }
+
+    private Mono<Void> tooManyRequest(ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+        exchange.getResponse().getHeaders().set("Retry-After", "60");
+        return exchange.getResponse().setComplete();
+    }
+}

--- a/backend/api-gateway/src/main/resources/application.properties
+++ b/backend/api-gateway/src/main/resources/application.properties
@@ -29,3 +29,5 @@ management.endpoint.health.show-details=when-authorized
 
 rate-limit.public.max=20
 rate-limit.auth.max=200
+
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:4200}

--- a/backend/api-gateway/src/main/resources/application.properties
+++ b/backend/api-gateway/src/main/resources/application.properties
@@ -15,9 +15,17 @@ jwt.secret=${JWT_SECRET}
 service.auth-url=${AUTH_SERVICE_URL:http://localhost:8081}
 service.user-url=${USER_SERVICE_URL:http://localhost:8082}
 service.restaurant-url=${RESTAURANT_SERVICE_URL:http://localhost:8083}
+service.order-url=${ORDER_SERVICE_URL:http://localhost:8084}
+service.payment-url=${PAYMENT_SERVICE_URL:http://localhost:8085}
+service.notification-url=${NOTIFICATION_SERVICE_URL:http://localhost:8086}
+service.delivery-url=${DELIVERY_SERVICE_URL:http://localhost:8087}
+service.review-url=${REVIEW_SERVICE_URL:http://localhost:8088}
 
 # Actuator — port 9090 isolated from public traffic (Prometheus scrapes directly)
 management.server.port=9090
 management.server.address=127.0.0.1
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=when-authorized
+
+rate-limit.public.max=20
+rate-limit.auth.max=200

--- a/backend/api-gateway/src/test/java/com/gosqu/gateway/filter/JwtAuthenticationFilterTest.java
+++ b/backend/api-gateway/src/test/java/com/gosqu/gateway/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,170 @@
+package com.gosqu.gateway.filter;
+
+import com.gosqu.gateway.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private GatewayFilterChain chain;
+
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JwtAuthenticationFilter(jwtUtil);
+        lenient().when(chain.filter(any())).thenReturn(Mono.empty());
+    }
+
+    @Test
+    @DisplayName("public path /auth/login passes through without JWT")
+    void publicPath_authLogin_passesThrough() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/auth/login").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(chain).filter(any());
+    }
+
+    @Test
+    @DisplayName("public path /oauth2/authorization passes through without JWT")
+    void publicPath_oauth2_passesThrough() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/oauth2/authorization/google").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(chain).filter(any());
+    }
+
+    @Test
+    @DisplayName("protected path without Authorization header returns 401")
+    void protectedPath_missingToken_returns401() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/users/me").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    @DisplayName("Authorization header without Bearer prefix return 401")
+    void malformedBearer_returns401() {
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/order/1")
+                        .header("Authorization", "Basic dXNlcjpwYXNz")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    @DisplayName("invalid JWT returns 401")
+    void invalidToken_returns401() {
+        when(jwtUtil.extractClaims("bad.token")).thenThrow(new JwtException("invalid"));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/users/me")
+                        .header("Authorization", "Bearer bad.token")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    @DisplayName("valid JWT injects X-User-* headers into downstream request")
+    void validToken_injectsUserHeaders() {
+        Claims claims = mock(Claims.class);
+        when(claims.getSubject()).thenReturn("gosqu@gosqu.com");
+        when(claims.get("role", String.class)).thenReturn("ADMIN");
+        when(claims.get("userId", Long.class)).thenReturn(777L);
+        when(jwtUtil.extractClaims("valid.token")).thenReturn(claims);
+
+        ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+        when(chain.filter(captor.capture())).thenReturn(Mono.empty());
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/users/me")
+                        .header("Authorization", "Bearer valid.token")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        var headers = captor.getValue().getRequest().getHeaders();
+        assertThat(headers.getFirst("X-User-Email")).isEqualTo("gosqu@gosqu.com");
+        assertThat(headers.getFirst("X-User-Role")).isEqualTo("ADMIN");
+        assertThat(headers.getFirst("X-User-Id")).isEqualTo("777");
+    }
+
+    @Test
+    @DisplayName("client-injected trust headers are stripped")
+    void clientInjectedTrustHeaders_areStripped() {
+        ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+        when(chain.filter(captor.capture())).thenReturn(Mono.empty());
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/auth/login")
+                        .header("X-User-Id", "999")
+                        .header("X-User-Email", "hacker@evil.com")
+                        .header("X-User-Role", "ADMIN")
+                        .header("X-Internal-Service", "true")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        var headers = captor.getValue().getRequest().getHeaders();
+        assertThat(headers.getFirst("X-User-Id")).isNull();
+        assertThat(headers.getFirst("X-User-Email")).isNull();
+        assertThat(headers.getFirst("X-User-Role")).isNull();
+        assertThat(headers.getFirst("X-Internal-Service")).isNull();
+    }
+
+    @Test
+    @DisplayName("filter order is -1")
+    void filterOrder_isMinusOne() {
+        assertThat(filter.getOrder()).isEqualTo(-1);
+    }
+
+}

--- a/backend/api-gateway/src/test/java/com/gosqu/gateway/filter/RateLimitFilterTest.java
+++ b/backend/api-gateway/src/test/java/com/gosqu/gateway/filter/RateLimitFilterTest.java
@@ -1,0 +1,168 @@
+package com.gosqu.gateway.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitFilterTest {
+
+    @Mock
+    private ReactiveStringRedisTemplate redisTemplate;
+
+    @Mock
+    private ReactiveValueOperations<String, String> valueOps;
+
+    @Mock
+    private GatewayFilterChain chain;
+
+    private RateLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new RateLimitFilter(redisTemplate);
+        ReflectionTestUtils.setField(filter, "publicMax", 3);
+        ReflectionTestUtils.setField(filter, "authMax", 10);
+
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        lenient().when(redisTemplate.expire(any(), any())).thenReturn(Mono.just(true));
+        lenient().when(chain.filter(any())).thenReturn(Mono.empty());
+    }
+
+    @Test
+    @DisplayName("request under limit passes through")
+    void belowLimit_passesThrough() {
+        when(valueOps.increment(any())).thenReturn(Mono.just(1L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(chain).filter(any());
+    }
+
+    @Test
+    @DisplayName("request over public limit return 429")
+    void abovePublicLimit_returns429() {
+        when(valueOps.increment(any())).thenReturn(Mono.just(4L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants").build());
+
+        StepVerifier.create(filter.filter(exchange,chain))
+                .verifyComplete();
+
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    @DisplayName("request over auth limit return 429")
+    void aboveAuthLimit_returns429() {
+        when(valueOps.increment(any())).thenReturn(Mono.just(11L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants").build());
+
+        StepVerifier.create(filter.filter(exchange,chain))
+                .verifyComplete();
+
+        verify(chain, never()).filter(any());
+    }
+
+    @Test
+    @DisplayName("authenticated user uses per-user key in Redis")
+    void authenticatedRequest_usesUserKey() {
+        when(valueOps.increment(argThat(key -> key.contains("user:42")))).thenReturn(Mono.just(1L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants")
+                        .header("X-User-Id", "42")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(valueOps).increment(argThat(key -> key.startsWith("rate_limit:user:42:")));
+    }
+
+    @Test
+    @DisplayName("unauthenticated user uses per-ip key in Redis")
+    void unauthenticatedRequest_usesIpKey() {
+        when(valueOps.increment(argThat(key -> key.startsWith("rate_limit:ip:")))).thenReturn(Mono.just(1L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/auth/login").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(valueOps).increment(argThat(key -> key.startsWith("rate_limit:ip:")));
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For used as client IP")
+    void xForwardedFor_usedAsClientIp() {
+        when(valueOps.increment(argThat(key -> key.contains("10.0.0.5")))).thenReturn(Mono.just(1L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/auth/login")
+                        .header("X-Forwarded-For", "10.0.0.5, 172.16.0.1")
+                        .build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(valueOps).increment(argThat(key -> key.contains("10.0.0.5")));
+    }
+
+    @Test
+    @DisplayName("First request sets expire on key")
+    void firstRequest_setsExpireOnKey() {
+        when(valueOps.increment(any())).thenReturn(Mono.just(1L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(redisTemplate).expire(any(), any());
+    }
+
+    @Test
+    @DisplayName("Subsequent request does not reset expire")
+    void subsequentRequest_doesNotResetExpire() {
+        when(valueOps.increment(any())).thenReturn(Mono.just(2L));
+
+        var exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("/restaurants").build());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+                .verifyComplete();
+
+        verify(redisTemplate, never()).expire(any(), any());
+    }
+
+    @Test
+    @DisplayName("filter order is zero (after JwtAuthenticationFilter)")
+    void filterOrder_isZero() {
+        assertThat(filter.getOrder()).isEqualTo(0);
+    }
+}

--- a/backend/api-gateway/src/test/java/com/gosqu/gateway/util/JwtUtilTest.java
+++ b/backend/api-gateway/src/test/java/com/gosqu/gateway/util/JwtUtilTest.java
@@ -1,0 +1,91 @@
+package com.gosqu.gateway.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JwtUtilTest {
+
+    private static final String TEST_SECRET = Base64.getEncoder().encodeToString(
+            "webstaurator-test-secret-key-must-be-at-least-256-bits-long!!".getBytes());
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil(TEST_SECRET);
+    }
+
+    @Test
+    @DisplayName("extractClaims return correct subject, role, userId")
+    void extractClaims_validToken_returnCorrectClaims() {
+        String token = buildToken("gosqu@gosqu.com", "ADMIN", 777L, 3_600_000);
+
+        Claims claims = jwtUtil.extractClaims(token);
+
+        assertEquals("gosqu@gosqu.com", claims.getSubject());
+        assertEquals("ADMIN", claims.get("role", String.class));
+        assertEquals(777L, claims.get("userId", Long.class));
+    }
+
+    @Test
+    @DisplayName("isValid return true for fresh token")
+    void isValid_freshToken_returnsTrue() {
+        String token = buildToken("gosqu@test.gosqu", "CUSTOMER", 1L, 3_600_000);
+        assertThat(jwtUtil.isValid(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("isValid return false for expired token")
+    void isValid_expiredToken_returnsFalse() {
+        String token = buildToken("gosqu@gosqu.com", "CUSTOMER", 1L, -1_000);
+        assertThat(jwtUtil.isValid(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isValid return false for token signed with wrong secret")
+    void isValid_wrongSecret_returnsFalse() {
+        String wrongSecret = Base64.getEncoder().encodeToString(
+                "completely-different-secret-key-at-least-256-bits-long!!".getBytes());
+        SecretKey wrongKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(wrongSecret));
+        String tampered = Jwts.builder()
+                .subject("hacker@evil.com")
+                .expiration(new Date(System.currentTimeMillis() + 3_600_000))
+                .signWith(wrongKey)
+                .compact();
+
+        assertThat(jwtUtil.isValid(tampered)).isFalse();
+    }
+
+    @Test
+    @DisplayName("extractClaims throw JwtException for incorrect string")
+    void extractClaims_garbage_throwsJwtException() {
+        assertThatThrownBy(() -> jwtUtil.extractClaims("not.a.real.token"))
+                .isInstanceOf(JwtException.class);
+    }
+
+    private String buildToken(String email, String role, long userId, long expiresInMs) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(TEST_SECRET));
+        return Jwts.builder()
+                .subject(email)
+                .claim("role", role)
+                .claim("userId", userId)
+                .expiration(Date.from(Instant.now().plusSeconds(expiresInMs)))
+                .signWith(key)
+                .compact();
+    }
+}


### PR DESCRIPTION
---

### Description of Changes

This pull request introduces the following updates:

1. **Rate Limiting Implementation**:
   - Added a `RateLimitFilter` for API requests:
     - Public requests: 20 requests per minute.
     - Authenticated users: 200 requests per minute.
   - Leverages Redis for rate limit storage and enforcement.

2. **API Gateway Enhancements**:
   - Configured routes for multiple services (user, restaurant, order, payment, delivery, notification, review).
   - Enhanced `JwtAuthenticationFilter` to:
     - Strip client-injected trust headers.
     - Enrich downstream requests with `X-User-Id`.

3. **Configuration Updates**:
   - Added configurable properties for rate limits, microservices URLs, and CORS (`cors.allowed-origins`).

4. **Testing Improvements**:
   - Added comprehensive unit tests for `RateLimitFilter`:
     - Covers both authenticated and unauthenticated scenarios.
     - Validates interactions with Redis and filter setup.
   - Created unit tests for `JwtUtil` and `JwtAuthenticationFilter`.
   - Updated project dependencies (`reactor-test` added for testing purposes).

---

### Checklist

- [x] The changes have been tested.
- [ ] Documentation has been updated if necessary.
- [x] Related issues have been linked.

---